### PR TITLE
Refactor scripts to use centralized path helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ anime-dub/
 │  ├─ diarization/           # Résultats pyannote
 │  ├─ transcripts/
 │  │  ├─ whisper_json/       # Segments Whisper (ZH)
+│  │  ├─ whisper_json_fr/    # Segments Whisper traduits (ZH→FR)
 │  │  ├─ zh_srt/             # Sous-titres ZH
 │  │  └─ fr_srt/             # Sous-titres FR
 │  ├─ segments/              # Segments texte + personnage
@@ -91,3 +92,11 @@ anime-dub/
    ├─ paths.yaml
    ├─ characters.yaml
    └─ xtts_config.yaml
+
+Les scripts utilisent désormais `scripts/utils_config.py` pour charger ces fichiers de config et résoudre les chemins depuis la racine du projet. Les fonctions principales :
+
+- `get_data_path(key)`: récupère un `Path` à partir d'une clef définie dans `config/paths.yaml`.
+- `ensure_directories([...])`: crée (si besoin) les répertoires référencés et renvoie leur mapping.
+- `load_characters_config()` / `load_xtts_config()`: chargent les paramètres vocaux et XTTS.
+
+Cette factorisation prépare l'ajout d'une future interface GUI qui orchestrera l'exécution des étapes et l'édition des paramètres.

--- a/config/paths.yaml
+++ b/config/paths.yaml
@@ -11,6 +11,7 @@ diarization_dir: "data/diarization"
 
 transcripts_root: "data/transcripts"
 whisper_json_dir: "data/transcripts/whisper_json"
+whisper_json_fr_dir: "data/transcripts/whisper_json_fr"
 zh_srt_dir: "data/transcripts/zh_srt"
 fr_srt_dir: "data/transcripts/fr_srt"
 

--- a/scripts/01_extract_audio.py
+++ b/scripts/01_extract_audio.py
@@ -1,30 +1,38 @@
 # scripts/01_extract_audio.py
 import subprocess
-from pathlib import Path
 
-RAW = Path("data/episodes_raw")
-OUT = Path("data/audio_raw")
-OUT.mkdir(parents=True, exist_ok=True)
+from utils_config import ensure_directories, get_data_path
+
 
 def run(cmd):
     print(" ".join(cmd))
     subprocess.run(cmd, check=True)
 
-for video in RAW.glob("*.mkv"):
-    stem = video.stem
-    full_wav = OUT / f"{stem}_full.wav"
-    mono16 = OUT / f"{stem}_mono16k.wav"
 
-    # Audio full qualité
-    run([
-        "ffmpeg", "-y", "-i", str(video),
-        "-map", "0:a:0", "-c:a", "pcm_s16le",
-        str(full_wav)
-    ])
+def extract_audio_for_all_sources() -> None:
+    paths = ensure_directories(["audio_raw_dir"])
+    episodes_raw = get_data_path("episodes_raw_dir")
+    audio_raw = paths["audio_raw_dir"]
 
-    # Version mono 16k pour Whisper
-    run([
-        "ffmpeg", "-y", "-i", str(full_wav),
-        "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le",
-        str(mono16)
-    ])
+    for video in episodes_raw.glob("*.mkv"):
+        stem = video.stem
+        full_wav = audio_raw / f"{stem}_full.wav"
+        mono16 = audio_raw / f"{stem}_mono16k.wav"
+
+        # Audio full qualité
+        run([
+            "ffmpeg", "-y", "-i", str(video),
+            "-map", "0:a:0", "-c:a", "pcm_s16le",
+            str(full_wav)
+        ])
+
+        # Version mono 16k pour Whisper
+        run([
+            "ffmpeg", "-y", "-i", str(full_wav),
+            "-ac", "1", "-ar", "16000", "-c:a", "pcm_s16le",
+            str(mono16)
+        ])
+
+
+if __name__ == "__main__":
+    extract_audio_for_all_sources()

--- a/scripts/05_build_speaker_bank.py
+++ b/scripts/05_build_speaker_bank.py
@@ -1,15 +1,9 @@
 # scripts/05_build_speaker_bank.py
-from pathlib import Path
 import numpy as np
 import soundfile as sf
 from pyannote.audio import Model
-from pyannote.audio.pipelines.utils.hook import ProgressHook
-from pyannote.audio.pipelines.utils import SpeakerDiarizationMixin
 
-AUDIO_RAW = Path("data/audio_raw")
-DIAR = Path("data/diarization")
-BANK = Path("data/speaker_bank")
-BANK.mkdir(parents=True, exist_ok=True)
+from utils_config import ensure_directories
 
 # Modèle d'embedding de locuteur pyannote (exemple)
 embed_model = Model.from_pretrained(
@@ -18,6 +12,7 @@ embed_model = Model.from_pretrained(
 )
 
 SAMPLE_RATE = 16000  # à adapter selon ton audio
+
 
 def get_embedding(wav_path, start, end):
     audio, sr = sf.read(wav_path)
@@ -29,8 +24,18 @@ def get_embedding(wav_path, start, end):
     emb = embed_model({"waveform": np.expand_dims(chunk, 0), "sample_rate": sr})
     return emb.detach().cpu().numpy().squeeze()
 
+
+def prepare_bank_directories() -> None:
+    ensure_directories(["speaker_bank_dir"])
+
+
 # Ensuite tu peux :
 # - sélectionner quelques épisodes (manuellement dans le script)
 # - pour chaque segment (RTTM), calculer un embedding
 # - les stocker dans un .npz par épisode pour ensuite les clusteriser avec sklearn
+
+
+if __name__ == "__main__":
+    # Prépare simplement la structure pour la prochaine étape GUI / clustering.
+    prepare_bank_directories()
 

--- a/scripts/08_mix_audio.py
+++ b/scripts/08_mix_audio.py
@@ -1,26 +1,34 @@
 # scripts/08_mix_audio.py
 import subprocess
-from pathlib import Path
 
-RAW = Path("data/audio_raw")
-DUB = Path("data/dub_audio")
+from utils_config import ensure_directories, get_data_path
+
 
 def run(cmd):
     print(" ".join(cmd))
     subprocess.run(cmd, check=True)
 
-for voices in DUB.glob("*_fr_voices.wav"):
-    stem = voices.stem.replace("_fr_voices", "")
-    original = RAW / f"{stem}_full.wav"
-    out_mix = DUB / f"{stem}_fr_full.wav"
 
-    # Ex : original volume 0.5, voix FR 1.2
-    run([
-        "ffmpeg", "-y",
-        "-i", str(original),
-        "-i", str(voices),
-        "-filter_complex",
-        "[0:a]volume=0.5[a0];[1:a]volume=1.2[a1];[a0][a1]amix=inputs=2:dropout_transition=0",
-        "-c:a", "aac",
-        str(out_mix)
-    ])
+def mix_all():
+    paths = ensure_directories(["dub_audio_dir"])
+    raw_dir = get_data_path("audio_raw_dir")
+    dub_dir = paths["dub_audio_dir"]
+
+    for voices in dub_dir.glob("*_fr_voices.wav"):
+        stem = voices.stem.replace("_fr_voices", "")
+        original = raw_dir / f"{stem}_full.wav"
+        out_mix = dub_dir / f"{stem}_fr_full.wav"
+
+        run([
+            "ffmpeg", "-y",
+            "-i", str(original),
+            "-i", str(voices),
+            "-filter_complex",
+            "[0:a]volume=0.5[a0];[1:a]volume=1.2[a1];[a0][a1]amix=inputs=2:dropout_transition=0",
+            "-c:a", "aac",
+            str(out_mix)
+        ])
+
+
+if __name__ == "__main__":
+    mix_all()

--- a/scripts/09_remux.py
+++ b/scripts/09_remux.py
@@ -1,29 +1,37 @@
 # scripts/09_remux.py
 import subprocess
-from pathlib import Path
 
-VID = Path("data/episodes_raw")
-DUB = Path("data/dub_audio")
-OUT = Path("data/episodes_dubbed")
-OUT.mkdir(parents=True, exist_ok=True)
+from utils_config import ensure_directories, get_data_path
+
 
 def run(cmd):
     print(" ".join(cmd))
     subprocess.run(cmd, check=True)
 
-for mix in DUB.glob("*_fr_full.wav"):
-    stem = mix.stem.replace("_fr_full", "")
-    src = VID / f"{stem}.mkv"
-    out = OUT / f"{stem}_FR.mkv"
 
-    run([
-        "ffmpeg", "-y",
-        "-i", str(src),
-        "-i", str(mix),
-        "-map", "0:v:0", "-map", "1:a:0",
-        "-c:v", "copy",
-        "-c:a", "aac",
-        "-shortest",
-        "-metadata:s:a:0", "language=fra",
-        str(out)
-    ])
+def remux_all():
+    paths = ensure_directories(["episodes_dubbed_dir"])
+    vid_dir = get_data_path("episodes_raw_dir")
+    dub_dir = get_data_path("dub_audio_dir")
+    out_dir = paths["episodes_dubbed_dir"]
+
+    for mix in dub_dir.glob("*_fr_full.wav"):
+        stem = mix.stem.replace("_fr_full", "")
+        src = vid_dir / f"{stem}.mkv"
+        out = out_dir / f"{stem}_FR.mkv"
+
+        run([
+            "ffmpeg", "-y",
+            "-i", str(src),
+            "-i", str(mix),
+            "-map", "0:v:0", "-map", "1:a:0",
+            "-c:v", "copy",
+            "-c:a", "aac",
+            "-shortest",
+            "-metadata:s:a:0", "language=fra",
+            str(out)
+        ])
+
+
+if __name__ == "__main__":
+    remux_all()

--- a/scripts/utils_config.py
+++ b/scripts/utils_config.py
@@ -8,7 +8,7 @@ Utilitaires pour charger les fichiers de configuration YAML du projet.
 """
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Iterable
 import yaml
 
 
@@ -90,3 +90,29 @@ def get_data_path(key: str) -> Path:
     if key not in paths_cfg:
         raise KeyError(f"Clé '{key}' absente de paths.yaml")
     return PROJECT_ROOT / paths_cfg[key]
+
+
+def get_path_map(keys: Iterable[str]) -> Dict[str, Path]:
+    """
+    Renvoie un dictionnaire {clef: Path} pour une sélection de clefs
+    définies dans ``config/paths.yaml``.
+
+    :param keys: liste de clefs à résoudre (ex: ["audio_raw_dir", "diarization_dir"]).
+    :return: dictionnaire clef -> pathlib.Path
+    """
+    return {key: get_data_path(key) for key in keys}
+
+
+def ensure_directories(keys: Iterable[str]) -> Dict[str, Path]:
+    """
+    Crée (si nécessaire) les répertoires correspondant aux clefs fournies
+    et renvoie le mapping des chemins résolus. Utile pour initialiser la
+    structure attendue avant l'exécution d'un script ou d'une future GUI.
+
+    :param keys: clefs de ``config/paths.yaml`` à créer si absentes.
+    :return: dictionnaire clef -> pathlib.Path existants/garantis.
+    """
+    paths = get_path_map(keys)
+    for path in paths.values():
+        path.mkdir(parents=True, exist_ok=True)
+    return paths


### PR DESCRIPTION
## Summary
- refactor all pipeline scripts to resolve paths via scripts/utils_config.py and config/paths.yaml
- align directories with the documented data layout and add a translated Whisper JSON output folder
- prepare XTTS, character assignment, and speaker bank steps for future GUI orchestration

## Testing
- python -m compileall scripts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6936536f519483239fb0170e43eda2c6)