### PR TITLE
Normalize stem filtering and prioritize vocal stems for Whisper

### DIFF
--- a/scripts/04_whisper_transcribe.py
+++ b/scripts/04_whisper_transcribe.py
@@ -3,11 +3,16 @@ import argparse
 import json
 import logging
 import os
+import subprocess
+from pathlib import Path
 from typing import Iterable
+
+import soundfile as sf
 from faster_whisper import WhisperModel
 
 from utils_config import ensure_directories, get_data_path
 from utils_logging import init_logger, parse_stems, should_verbose
+from utils_paths import normalized_filter, stem_matches_filter
 
 
 def write_srt(segments, srt_path):
@@ -27,15 +32,87 @@ def write_srt(segments, srt_path):
     srt_path.write_text("\n".join(lines), encoding="utf-8")
 
 
-def iter_sources(stems_filter: set[str] | None, logger: logging.Logger) -> Iterable[str]:
+def iter_sources(
+    stems_filter: set[str] | None, logger: logging.Logger
+) -> Iterable[tuple[str, Path, str]]:
+    """Détermine la source audio à transcrire (priorité aux stems vocaux)."""
+
+    audio_stems = get_data_path("audio_stems_dir")
     audio_raw = get_data_path("audio_raw_dir")
-    logger.debug("Recherche des wav 16 kHz dans %s", audio_raw)
-    for wav in sorted(audio_raw.glob("*_mono16k.wav")):
-        stem = wav.stem.replace("_mono16k", "")
-        if stems_filter and stem not in stems_filter:
-            logger.debug("Ignore %s car non sélectionné", stem)
+    logger.debug(
+        "Recherche des audios (priorité stems vocaux) dans %s puis %s", audio_stems, audio_raw
+    )
+
+    stems_filter_norm = normalized_filter(stems_filter)
+    chosen: dict[str, tuple[Path, str]] = {}
+
+    for wav in sorted(audio_stems.glob("*_vocals.wav")):
+        stem = wav.stem.removesuffix("_vocals")
+        if not stem_matches_filter(stem, stems_filter_norm):
+            logger.debug("Ignore %s car non sélectionné (stems)", stem)
             continue
-        yield stem
+        chosen[stem] = (wav, "stems (vocals)")
+
+    for pattern, suffix, desc in (
+        ("*_mono16k.wav", "_mono16k", "audio complet mono16k"),
+        ("*_full.wav", "_full", "audio complet brut"),
+    ):
+        for wav in sorted(audio_raw.glob(pattern)):
+            stem = wav.stem.replace(suffix, "")
+            if not stem_matches_filter(stem, stems_filter_norm):
+                logger.debug("Ignore %s car non sélectionné (audio brut)", stem)
+                continue
+            chosen.setdefault(stem, (wav, desc))
+
+    for stem in sorted(chosen):
+        yield stem, chosen[stem][0], chosen[stem][1]
+
+
+def ensure_mono16k(audio_path: Path, workdir: Path, logger: logging.Logger) -> Path:
+    """Garantit une source mono 16 kHz (conversion ffmpeg si nécessaire)."""
+
+    try:
+        info = sf.info(str(audio_path))
+        if info.channels == 1 and int(info.samplerate) == 16000:
+            logger.debug("Audio déjà mono 16 kHz : %s", audio_path)
+            return audio_path
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Lecture des métadonnées impossible pour %s (%s) ; conversion forcée en 16 kHz.",
+            audio_path,
+            exc,
+        )
+
+    workdir.mkdir(parents=True, exist_ok=True)
+    target = workdir / f"{audio_path.stem}_mono16k.wav"
+
+    if target.exists():
+        try:
+            t_info = sf.info(str(target))
+            if t_info.channels == 1 and int(t_info.samplerate) == 16000:
+                logger.debug("Réutilisation du cache 16 kHz : %s", target)
+                return target
+        except Exception:  # noqa: BLE001
+            logger.debug("Cache 16 kHz invalide, nouvelle conversion : %s", target)
+
+    logger.info("Conversion 16 kHz (mono) pour Whisper : %s", audio_path)
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(audio_path),
+            "-ac",
+            "1",
+            "-ar",
+            "16000",
+            "-c:a",
+            "pcm_s16le",
+            str(target),
+        ],
+        check=True,
+    )
+    return target
 
 
 def transcribe_all(
@@ -45,22 +122,22 @@ def transcribe_all(
 ) -> None:
     logger = init_logger("whisper_transcribe", verbose, logger)
 
-    paths = ensure_directories(["whisper_json_dir", "zh_srt_dir"])
-    audio_raw = get_data_path("audio_raw_dir")
+    paths = ensure_directories(["whisper_json_dir", "zh_srt_dir", "transcripts_root"])
     out_json = paths["whisper_json_dir"]
     out_srt = paths["zh_srt_dir"]
+    whisper_work = paths["transcripts_root"] / "whisper_wav16k"
 
     model_size = "large-v3"
     logger.info("Chargement du modèle Whisper %s", model_size)
     model = WhisperModel(model_size, device="cuda", compute_type="float16")
 
     processed_any = False
-    for stem in iter_sources(stems, logger):
-        wav = audio_raw / f"{stem}_mono16k.wav"
+    for stem, source_path, source_desc in iter_sources(stems, logger):
+        wav = ensure_mono16k(source_path, whisper_work, logger)
         json_path = out_json / f"{stem}.json"
         srt_path = out_srt / f"{stem}_zh.srt"
 
-        logger.info("Transcription : %s", wav)
+        logger.info("Transcription (%s) : %s", source_desc, wav)
 
         segments_out = []
         segments, info = model.transcribe(str(wav), language="zh", beam_size=5)
@@ -92,6 +169,7 @@ if __name__ == "__main__":
     logger = init_logger("whisper_transcribe", verbose)
 
     stems_filter = parse_stems(args.stem, logger)
-    logger.info("Stems ciblés : %s", sorted(stems_filter) if stems_filter else "tous")
+    stems_display = sorted(normalized_filter(stems_filter)) if stems_filter else "tous"
+    logger.info("Stems ciblés (normalisés) : %s", stems_display)
 
     transcribe_all(stems_filter, verbose=verbose, logger=logger)

--- a/scripts/05_translate_nllb.py
+++ b/scripts/05_translate_nllb.py
@@ -76,7 +76,7 @@ def translate_all(
     out_json_dir = paths["whisper_json_fr_dir"]
     out_srt_dir = paths["fr_srt_dir"]
 
-    model_name = "facebook/nllb-200-1.3B"
+    model_name = "facebook/nllb-200-distilled-1.3B"
     logger.info("Chargement du modèle NLLB %s", model_name)
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForSeq2SeqLM.from_pretrained(model_name).to("cuda")

--- a/scripts/05_translate_nllb.py
+++ b/scripts/05_translate_nllb.py
@@ -76,7 +76,7 @@ def translate_all(
     out_json_dir = paths["whisper_json_fr_dir"]
     out_srt_dir = paths["fr_srt_dir"]
 
-    model_name = "facebook/nllb-200-distilled-600M"
+    model_name = "facebook/nllb-200-1.3B"
     logger.info("Chargement du modèle NLLB %s", model_name)
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     model = AutoModelForSeq2SeqLM.from_pretrained(model_name).to("cuda")

--- a/scripts/09_mix_audio.py
+++ b/scripts/09_mix_audio.py
@@ -7,6 +7,7 @@ from typing import Iterable
 
 from utils_config import ensure_directories, get_data_path
 from utils_logging import init_logger, parse_stems, should_verbose
+from utils_paths import normalized_filter, stem_matches_filter
 
 
 def run(cmd: list[str], logger: logging.Logger, verbose: bool) -> None:
@@ -21,9 +22,10 @@ def run(cmd: list[str], logger: logging.Logger, verbose: bool) -> None:
 def iter_targets(stems_filter: set[str] | None, logger: logging.Logger) -> Iterable[str]:
     dub_dir = get_data_path("dub_audio_dir")
     logger.debug("Recherche des voix FR dans %s", dub_dir)
+    stems_filter_norm = normalized_filter(stems_filter)
     for voices in sorted(dub_dir.glob("*_fr_voices.wav")):
         stem = voices.stem.replace("_fr_voices", "")
-        if stems_filter and stem not in stems_filter:
+        if not stem_matches_filter(stem, stems_filter_norm):
             logger.debug("Ignore %s car non sélectionné", stem)
             continue
         yield stem
@@ -80,7 +82,8 @@ def main():
     logger = init_logger("mix_audio", verbose)
 
     stems_filter = parse_stems(args.stem, logger)
-    logger.info("Stems ciblés : %s", sorted(stems_filter) if stems_filter else "tous")
+    stems_display = sorted(normalized_filter(stems_filter)) if stems_filter else "tous"
+    logger.info("Stems ciblés (normalisés) : %s", stems_display)
 
     mix_all(stems_filter, verbose=verbose, logger=logger)
 

--- a/scripts/gui_pipeline.py
+++ b/scripts/gui_pipeline.py
@@ -63,7 +63,7 @@ STEPS: list[WorkflowStep] = [
     WorkflowStep("02", "Séparation stems", "02_separate_stems.py", "audio_raw_dir", "*_full.wav", "Demucs/UVR", supports_verbose=True),
     WorkflowStep("03", "Diarisation", "03_diarize.py", "audio_raw_dir", "*_mono16k.wav", "pyannote 3.1"),
     WorkflowStep("04", "Transcription Whisper", "04_whisper_transcribe.py", "audio_raw_dir", "*_mono16k.wav", "Whisper large-v3"),
-    WorkflowStep("05", "Traduction NLLB", "05_translate_nllb.py", "whisper_json_dir", "*.json", "NLLB 1.3B"),
+    WorkflowStep("05", "Traduction NLLB", "05_translate_nllb.py", "whisper_json_dir", "*.json", "NLLB distillé 1.3B"),
     WorkflowStep("06", "Banque de voix", "06_build_speaker_bank.py", None, None, "Initialisation/embeddings"),
     WorkflowStep("07", "Attribution personnages", "07_assign_characters.py", "whisper_json_fr_dir", "*_fr.json", "Matching embeddings"),
     WorkflowStep("08", "Synthèse XTTS", "08_synthesize_xtts.py", "segments_dir", "*_segments.json", "XTTS-v2"),

--- a/scripts/gui_pipeline.py
+++ b/scripts/gui_pipeline.py
@@ -63,7 +63,7 @@ STEPS: list[WorkflowStep] = [
     WorkflowStep("02", "Séparation stems", "02_separate_stems.py", "audio_raw_dir", "*_full.wav", "Demucs/UVR", supports_verbose=True),
     WorkflowStep("03", "Diarisation", "03_diarize.py", "audio_raw_dir", "*_mono16k.wav", "pyannote 3.1"),
     WorkflowStep("04", "Transcription Whisper", "04_whisper_transcribe.py", "audio_raw_dir", "*_mono16k.wav", "Whisper large-v3"),
-    WorkflowStep("05", "Traduction NLLB", "05_translate_nllb.py", "whisper_json_dir", "*.json", "NLLB 600M"),
+    WorkflowStep("05", "Traduction NLLB", "05_translate_nllb.py", "whisper_json_dir", "*.json", "NLLB 1.3B"),
     WorkflowStep("06", "Banque de voix", "06_build_speaker_bank.py", None, None, "Initialisation/embeddings"),
     WorkflowStep("07", "Attribution personnages", "07_assign_characters.py", "whisper_json_fr_dir", "*_fr.json", "Matching embeddings"),
     WorkflowStep("08", "Synthèse XTTS", "08_synthesize_xtts.py", "segments_dir", "*_segments.json", "XTTS-v2"),


### PR DESCRIPTION
## Summary
- normalize stem filtering across transcription, translation, synthesis, mix, and remux steps so legacy names with spaces are handled while outputs stay underscored
- update Whisper transcription to prioritize vocal stems and convert to mono 16 kHz only when needed
- log normalized stem targets in CLIs to encourage consistent naming

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693b9436e84883238dee3b13ef40fa61)