### PR TITLE
Add Whisper cleaning step and route translation to cleaned output

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ anime-dub/
 │  ├─ audio_stems/           # Stems (vocals, instrumental)
 │  ├─ diarization/           # Résultats pyannote
 │  ├─ transcripts/
-│  │  ├─ whisper_json/       # Segments Whisper (ZH)
+│  │  ├─ whisper_json/       # Segments Whisper (ZH) + variantes nettoyées *_clean_zh.json
 │  │  ├─ whisper_json_fr/    # Segments Whisper traduits (ZH→FR)
 │  │  ├─ zh_srt/             # Sous-titres ZH
 │  │  └─ fr_srt/             # Sous-titres FR

--- a/scripts/04_whisper_transcribe.py
+++ b/scripts/04_whisper_transcribe.py
@@ -10,6 +10,7 @@ from typing import Iterable
 import soundfile as sf
 from faster_whisper import WhisperModel
 
+from clean_whisper_json import DEFAULT_CONFIG, clean_whisper_json
 from utils_config import ensure_directories, get_data_path
 from utils_logging import init_logger, parse_stems, should_verbose
 from utils_paths import normalized_filter, stem_matches_filter
@@ -135,6 +136,8 @@ def transcribe_all(
     for stem, source_path, source_desc in iter_sources(stems, logger):
         wav = ensure_mono16k(source_path, whisper_work, logger)
         json_path = out_json / f"{stem}.json"
+        clean_json_path = out_json / f"{stem}_clean_zh.json"
+        report_path = out_json / f"{stem}_clean_report.json"
         srt_path = out_srt / f"{stem}_zh.srt"
 
         logger.info("Transcription (%s) : %s", source_desc, wav)
@@ -152,6 +155,12 @@ def transcribe_all(
 
         json_path.write_text(json.dumps({"segments": segments_out}, ensure_ascii=False, indent=2), encoding="utf-8")
         write_srt(segments_out, srt_path)
+        clean_whisper_json(
+            str(json_path),
+            str(clean_json_path),
+            str(report_path),
+            DEFAULT_CONFIG,
+        )
         logger.info("Whisper OK : %s", stem)
         processed_any = True
 

--- a/scripts/clean_whisper_json.py
+++ b/scripts/clean_whisper_json.py
@@ -1,0 +1,188 @@
+"""Nettoyage des transcriptions Whisper pour la traduction.
+
+Cette étape filtre les segments bruités, fusionne les doublons
+consécutifs et produit un JSON prêt pour la traduction (champs
+``text_zh``) ainsi qu'un rapport détaillé de nettoyage.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Iterable
+
+DEFAULT_CONFIG = {
+    "promo_keywords": [
+        "关注",
+        "订阅",
+        "点赞",
+        "转发",
+        "打赏",
+        "腾讯视频",
+        "官方微信",
+    ],
+    "merge_short": False,
+    "merge_min_length": 20,
+    "merge_target_length": 35,
+    "max_pause": 1.0,
+    "allowed_single_chars": {"是", "嗯", "这", "叫"},
+}
+
+LATIN_RE = re.compile(r"[A-Za-z]{3,}")
+HANGUL_RE = re.compile(r"[\uac00-\ud7af]")
+REPEAT_CHAR_RE = re.compile(r"^(.)\1{2,}$")
+PUNCT_SPACES_RE = re.compile(r"[\s、，。,.！？!？；;:“”\"'’‘·`~\-\(\)\[\]{}…]+")
+
+
+def merge_duplicates(segments: list[dict]) -> tuple[list[dict], int]:
+    """Fusionne les doublons consécutifs basés sur une normalisation légère."""
+
+    def _normalize(text: str) -> str:
+        return PUNCT_SPACES_RE.sub("", text.strip())
+
+    merged: list[dict] = []
+    fusion_count = 0
+
+    for seg in segments:
+        norm = _normalize(seg["text_zh"])
+        if merged:
+            prev_norm = merged[-1].setdefault("_norm", _normalize(merged[-1]["text_zh"]))
+            if norm and norm == prev_norm:
+                merged[-1]["end"] = max(merged[-1]["end"], seg["end"])
+                fusion_count += 1
+                continue
+        seg_copy = dict(seg)
+        seg_copy["_norm"] = norm
+        merged.append(seg_copy)
+
+    for seg in merged:
+        seg.pop("_norm", None)
+    return merged, fusion_count
+
+
+def merge_short_segments(segments: list[dict], config: dict) -> tuple[list[dict], int]:
+    """Regroupe les segments trop courts (optionnel)."""
+    if not config.get("merge_short"):
+        return segments, 0
+
+    max_pause = float(config.get("max_pause", DEFAULT_CONFIG["max_pause"]))
+    min_len = int(config.get("merge_min_length", DEFAULT_CONFIG["merge_min_length"]))
+    target_len = int(config.get("merge_target_length", DEFAULT_CONFIG["merge_target_length"]))
+
+    merged: list[dict] = []
+    merge_count = 0
+    i = 0
+    while i < len(segments):
+        current = dict(segments[i])
+        buffer_text = current["text_zh"]
+        start = current["start"]
+        end = current["end"]
+        j = i + 1
+        while j < len(segments) and len(buffer_text) < target_len:
+            gap = segments[j]["start"] - end
+            if gap > max_pause:
+                break
+            next_text = segments[j]["text_zh"]
+            prospective_len = len(buffer_text) + len(next_text)
+            if len(buffer_text) >= min_len and prospective_len > target_len:
+                break
+            buffer_text += next_text
+            end = segments[j]["end"]
+            j += 1
+            merge_count += 1
+            if len(buffer_text) >= min_len and gap > max_pause:
+                break
+        merged.append({"start": start, "end": end, "text_zh": buffer_text, **{k: v for k, v in current.items() if k not in {"start", "end", "text_zh"}}})
+        i = j
+    return merged, merge_count
+
+
+def should_drop(text: str, config: dict) -> tuple[bool, str | None]:
+    stripped = text.strip()
+    promo_keywords: Iterable[str] = config.get("promo_keywords", DEFAULT_CONFIG["promo_keywords"]) or []
+    allowed_single = set(config.get("allowed_single_chars", DEFAULT_CONFIG["allowed_single_chars"]))
+
+    if not stripped:
+        return True, "empty"
+    if any(word in stripped for word in promo_keywords):
+        return True, "promo"
+    if LATIN_RE.search(stripped):
+        return True, "latin"
+    if HANGUL_RE.search(stripped):
+        return True, "hangul"
+    condensed = PUNCT_SPACES_RE.sub("", stripped)
+    if len(condensed) == 1 and condensed not in allowed_single:
+        return True, "short_fragment"
+    if REPEAT_CHAR_RE.match(condensed):
+        return True, "repeat"
+    return False, None
+
+
+def clean_whisper_json(in_path: str, out_path: str, report_path: str, config: dict | None = None) -> None:
+    """Nettoie un JSON Whisper et écrit un rapport."""
+    cfg = dict(DEFAULT_CONFIG)
+    if config:
+        cfg.update(config)
+
+    src = Path(in_path)
+    data = json.loads(src.read_text(encoding="utf-8"))
+    segments = data.get("segments", [])
+
+    removed_examples: list[dict] = []
+    removed_counts = {k: 0 for k in ["promo", "latin", "hangul", "empty", "short_fragment", "repeat"]}
+
+    cleaned: list[dict] = []
+    for seg in segments:
+        text = str(seg.get("text", ""))
+        drop, reason = should_drop(text, cfg)
+        if drop:
+            if reason:
+                removed_counts[reason] += 1
+            if len(removed_examples) < 20:
+                removed_examples.append({"text": text, "reason": reason})
+            continue
+        cleaned.append({
+            k: seg[k] for k in seg if k != "text"
+        } | {"text_zh": text.strip()})
+
+    deduped, duplicate_fusions = merge_duplicates(cleaned)
+    merged, short_merges = merge_short_segments(deduped, cfg)
+
+    output = {"segments": merged}
+    Path(out_path).write_text(json.dumps(output, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    report = {
+        "segments_in": len(segments),
+        "segments_after_filter": len(cleaned),
+        "segments_out": len(merged),
+        "removed": removed_counts,
+        "duplicate_fusions": duplicate_fusions,
+        "short_merges": short_merges,
+        "examples_removed": removed_examples,
+    }
+    Path(report_path).write_text(json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Nettoyage des transcriptions Whisper (ZH)")
+    parser.add_argument("in_path", help="JSON Whisper brut")
+    parser.add_argument("out_path", help="JSON nettoyé (_clean_zh.json)")
+    parser.add_argument("report_path", help="Rapport de nettoyage")
+    parser.add_argument("--merge-short", action="store_true", dest="merge_short", help="Active le regroupement de segments courts")
+    parser.add_argument("--max-pause", type=float, default=DEFAULT_CONFIG["max_pause"], help="Pause max (s) pour fusionner des segments courts")
+    parser.add_argument("--merge-min-length", type=int, default=DEFAULT_CONFIG["merge_min_length"], help="Longueur minimale cible pour fusionner les segments courts")
+    parser.add_argument("--merge-target-length", type=int, default=DEFAULT_CONFIG["merge_target_length"], help="Longueur maximale approximative après fusion de courts segments")
+    args = parser.parse_args()
+
+    config = {
+        "merge_short": args.merge_short,
+        "merge_min_length": args.merge_min_length,
+        "merge_target_length": args.merge_target_length,
+        "max_pause": args.max_pause,
+    }
+    clean_whisper_json(args.in_path, args.out_path, args.report_path, config)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/gui_pipeline.py
+++ b/scripts/gui_pipeline.py
@@ -63,7 +63,7 @@ STEPS: list[WorkflowStep] = [
     WorkflowStep("02", "Séparation stems", "02_separate_stems.py", "audio_raw_dir", "*_full.wav", "Demucs/UVR", supports_verbose=True),
     WorkflowStep("03", "Diarisation", "03_diarize.py", "audio_raw_dir", "*_mono16k.wav", "pyannote 3.1"),
     WorkflowStep("04", "Transcription Whisper", "04_whisper_transcribe.py", "audio_raw_dir", "*_mono16k.wav", "Whisper large-v3"),
-    WorkflowStep("05", "Traduction NLLB", "05_translate_nllb.py", "whisper_json_dir", "*.json", "NLLB distillé 1.3B"),
+    WorkflowStep("05", "Traduction NLLB", "05_translate_nllb.py", "whisper_json_dir", "*_clean_zh.json", "NLLB distillé 1.3B"),
     WorkflowStep("06", "Banque de voix", "06_build_speaker_bank.py", None, None, "Initialisation/embeddings"),
     WorkflowStep("07", "Attribution personnages", "07_assign_characters.py", "whisper_json_fr_dir", "*_fr.json", "Matching embeddings"),
     WorkflowStep("08", "Synthèse XTTS", "08_synthesize_xtts.py", "segments_dir", "*_segments.json", "XTTS-v2"),

--- a/tests/data/whisper_sample.json
+++ b/tests/data/whisper_sample.json
@@ -1,0 +1,17 @@
+{
+  "segments": [
+    {"start": 0.0, "end": 1.0, "text": "你好"},
+    {"start": 1.1, "end": 1.5, "text": "   "},
+    {"start": 1.6, "end": 2.0, "text": "关注点赞"},
+    {"start": 2.1, "end": 2.6, "text": "abcXYZ"},
+    {"start": 2.7, "end": 3.0, "text": "가나다"},
+    {"start": 3.1, "end": 3.2, "text": "嗯"},
+    {"start": 3.3, "end": 3.4, "text": "啊"},
+    {"start": 3.5, "end": 3.7, "text": "魂魂魂"},
+    {"start": 3.8, "end": 4.0, "text": "是星斗"},
+    {"start": 4.0, "end": 4.2, "text": " 是 星斗 "},
+    {"start": 5.0, "end": 5.2, "text": "这是"},
+    {"start": 5.3, "end": 5.5, "text": "一个"},
+    {"start": 5.6, "end": 5.8, "text": "测试"}
+  ]
+}

--- a/tests/test_clean_whisper_json.py
+++ b/tests/test_clean_whisper_json.py
@@ -1,0 +1,54 @@
+import json
+import tempfile
+from pathlib import Path
+import unittest
+
+from scripts.clean_whisper_json import DEFAULT_CONFIG, clean_whisper_json
+
+
+class CleanWhisperJsonTests(unittest.TestCase):
+    def test_noise_filtering_and_merging(self) -> None:
+        sample = Path("tests/data/whisper_sample.json")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "sample_clean.json"
+            report = Path(tmpdir) / "report.json"
+            config = {
+                "merge_short": True,
+                "merge_min_length": 4,
+                "merge_target_length": 12,
+                "max_pause": 0.5,
+                "promo_keywords": DEFAULT_CONFIG["promo_keywords"],
+            }
+            clean_whisper_json(str(sample), str(out), str(report), config)
+
+            cleaned = json.loads(out.read_text(encoding="utf-8"))
+            segments = cleaned["segments"]
+            self.assertEqual(4, len(segments))
+
+            # Vérifie la fusion des doublons ("是星斗" sur deux segments consécutifs)
+            third = segments[2]
+            self.assertEqual("是星斗", third["text_zh"])
+            self.assertAlmostEqual(3.8, third["start"])
+            self.assertAlmostEqual(4.2, third["end"])
+
+            # Vérifie le regroupement des courts segments finaux
+            last = segments[-1]
+            self.assertEqual("这是一个测试", last["text_zh"])
+            self.assertAlmostEqual(5.0, last["start"])
+            self.assertAlmostEqual(5.8, last["end"])
+
+            report_data = json.loads(report.read_text(encoding="utf-8"))
+            self.assertEqual(13, report_data["segments_in"])
+            self.assertEqual(4, report_data["segments_out"])
+            self.assertEqual(1, report_data["duplicate_fusions"])
+            self.assertGreaterEqual(report_data["short_merges"], 2)
+            self.assertEqual(1, report_data["removed"]["promo"])
+            self.assertEqual(1, report_data["removed"]["latin"])
+            self.assertEqual(1, report_data["removed"]["hangul"])
+            self.assertEqual(1, report_data["removed"]["empty"])
+            self.assertEqual(1, report_data["removed"]["short_fragment"])
+            self.assertEqual(1, report_data["removed"]["repeat"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a clean_whisper_json helper that filters noise, merges duplicate segments, and produces cleaned zh outputs plus reports
- run the cleaning step after Whisper transcription and route downstream translation/UI to *_clean_zh.json files
- add a sample Whisper JSON fixture and unit test covering filtering, duplicate fusion, and timecodes

## Testing
- python -m unittest discover -s tests -v


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693e1e15f1908323a311f1b945ac0858)